### PR TITLE
Move image fully to the background

### DIFF
--- a/styles/background.less
+++ b/styles/background.less
@@ -11,5 +11,6 @@
   bottom: 0;
   left: 0;
   right: 0;
+  z-index: -1;
   position: absolute;
 }


### PR DESCRIPTION
Added explicit z-index value to ensure the background image doesn’t appear in front of any additional elements in the tree view.

This package was conflicting with the `atom-tree-view-breadcrumb` package, appearing in front of the path created by that package. So that extra element in the tree view could be seen, due to the image transparency, but not clicked on. See this issue thread, atom-tree-view-breadcrumb: [Clickable breadcrumb #14](https://github.com/abe33/atom-tree-view-breadcrumb/issues/14).
